### PR TITLE
feat(api): optional x-api-key auth + unified error responses

### DIFF
--- a/apps/api-gateway/.env
+++ b/apps/api-gateway/.env
@@ -1,0 +1,2 @@
+PORT=4330
+API_KEY=dev-key-123

--- a/apps/api-gateway/docs/openapi.yaml
+++ b/apps/api-gateway/docs/openapi.yaml
@@ -32,6 +32,8 @@ paths:
     get:
       tags: [Robots]
       summary: List robots
+      security:
+        - ApiKeyAuth: []
       parameters:
         - in: query
           name: status
@@ -59,6 +61,8 @@ paths:
     get:
       tags: [Robots]
       summary: Get a robot by id
+      security:
+        - ApiKeyAuth: []
       parameters:
         - in: path
           name: id
@@ -85,6 +89,8 @@ paths:
       description: >
         - Always transitions the robot to returning_to_base.
         - If cancel reason is battery or hardware, robot becomes non-reassignable until recovered.
+      security:
+        - ApiKeyAuth: []
       parameters:
         - in: path
           name: id
@@ -118,6 +124,8 @@ paths:
     get:
       tags: [Missions]
       summary: List missions
+      security:
+        - ApiKeyAuth: []
       parameters:
         - in: query
           name: status
@@ -154,6 +162,8 @@ paths:
     get:
       tags: [Missions]
       summary: Get a mission by id
+      security:
+        - ApiKeyAuth: []
       parameters:
         - in: path
           name: id
@@ -177,6 +187,8 @@ paths:
     get:
       tags: [Stats]
       summary: Get aggregate mission stats
+      security:
+        - ApiKeyAuth: []
       responses:
         "200":
           description: OK
@@ -256,7 +268,7 @@ components:
           example: false
         message:
           type: string
-          example: server error
+          example: unauthorized
 
     AcceptedResponse:
       type: object

--- a/apps/frontend-next/lib/api.ts
+++ b/apps/frontend-next/lib/api.ts
@@ -1,20 +1,18 @@
 // apps/frontend-next/lib/api.ts
 import type { paths } from '@fleetops/types/src/generated';
+
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://127.0.0.1:4330';
+const API_KEY = process.env.NEXT_PUBLIC_API_KEY;
 
 type Missions200 = paths['/missions']['get']['responses']['200']['content']['application/json'];
 type Stats200 = paths['/stats']['get']['responses']['200']['content']['application/json'];
 
 async function http<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, {
-    ...init,
-    headers: { 'content-type': 'application/json', ...(init?.headers ?? {}) },
-    cache: 'no-store',
-  });
-  if (!res.ok) {
-    const msg = await res.text().catch(() => res.statusText);
-    throw new Error(`${res.status} ${res.statusText} - ${msg}`);
-  }
+  const headers: Record<string, string> = { 'content-type': 'application/json', ...(init?.headers as any) };
+  if (API_KEY) headers['x-api-key'] = API_KEY;
+
+  const res = await fetch(`${API_BASE}${path}`, { ...init, headers, cache: 'no-store' });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}: ${await res.text().catch(() => '')}`);
   return res.json() as Promise<T>;
 }
 

--- a/packages/types/src/generated.ts
+++ b/packages/types/src/generated.ts
@@ -344,7 +344,7 @@ export interface components {
         ErrorResponse: {
             /** @example false */
             success: boolean;
-            /** @example server error */
+            /** @example unauthorized */
             message: string;
         };
         AcceptedResponse: {


### PR DESCRIPTION
Adds x-api-key auth on robots/missions/stats, keeps /healthz and /events open, and standardizes error payloads.